### PR TITLE
cloud-browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cov_profile
 .history
 examples/**/package.json
 examples/**/package-lock.json
+deno.lock

--- a/examples/browser/extensions.mjs
+++ b/examples/browser/extensions.mjs
@@ -1,0 +1,43 @@
+/**
+ * Use browser extensions with Scrapfly Cloud Browser
+ *
+ * npm install scrapfly-sdk puppeteer-core
+ */
+import { ScrapflyClient, BrowserConfig } from 'scrapfly-sdk';
+import puppeteer from 'puppeteer-core';
+
+const client = new ScrapflyClient({
+    key: 'YOUR_API_KEY',
+});
+
+// List current extensions
+const { extensions, quota } = await client.cloudBrowserExtensionList();
+console.log(`Extensions: ${quota.used}/${quota.limit}`);
+
+if (extensions) {
+    for (const ext of extensions) {
+        console.log(`  ${ext.id} - ${ext.name} v${ext.version}`);
+    }
+}
+
+// Connect with extensions enabled
+const EXTENSION_IDS = extensions?.map(e => e.id) || [];
+
+if (EXTENSION_IDS.length > 0) {
+    const config = new BrowserConfig({
+        proxy_pool: 'datacenter',
+        os: 'linux',
+        extensions: EXTENSION_IDS,
+    });
+
+    const wsUrl = client.cloudBrowser(config);
+    const browser = await puppeteer.connect({ browserWSEndpoint: wsUrl });
+
+    const page = await browser.newPage();
+    await page.goto('https://web-scraping.dev');
+    console.log('Page title:', await page.title());
+
+    await browser.close();
+} else {
+    console.log('No extensions uploaded. Upload one first via the dashboard or SDK.');
+}

--- a/examples/browser/playwright_connect.mjs
+++ b/examples/browser/playwright_connect.mjs
@@ -1,0 +1,38 @@
+/**
+ * Connect Playwright to Scrapfly Cloud Browser
+ *
+ * npm install scrapfly-sdk playwright
+ */
+import { ScrapflyClient, BrowserConfig } from 'scrapfly-sdk';
+import { chromium } from 'playwright';
+
+const client = new ScrapflyClient({
+    key: 'YOUR_API_KEY',
+});
+
+const config = new BrowserConfig({
+    proxy_pool: 'datacenter',
+    os: 'linux',
+});
+
+const wsUrl = client.cloudBrowser(config);
+
+const browser = await chromium.connectOverCDP(wsUrl);
+const context = browser.contexts()[0];
+const page = context.pages()[0] || await context.newPage();
+
+await page.goto('https://web-scraping.dev/products');
+
+const title = await page.title();
+console.log('Page title:', title);
+
+// Extract product data using Playwright locators
+const products = await page.locator('.product').evaluateAll(elements =>
+    elements.map(el => ({
+        title: el.querySelector('.product-title')?.textContent?.trim(),
+        price: el.querySelector('.product-price')?.textContent?.trim(),
+    }))
+);
+console.log('Products:', products);
+
+await browser.close();

--- a/examples/browser/puppeteer_connect.mjs
+++ b/examples/browser/puppeteer_connect.mjs
@@ -1,0 +1,39 @@
+/**
+ * Connect Puppeteer to Scrapfly Cloud Browser
+ *
+ * npm install scrapfly-sdk puppeteer-core
+ */
+import { ScrapflyClient, BrowserConfig, ProxyPool, OperatingSystem } from 'scrapfly-sdk';
+import puppeteer from 'puppeteer-core';
+
+const client = new ScrapflyClient({
+    key: 'YOUR_API_KEY',
+});
+
+const config = new BrowserConfig({
+    proxy_pool: ProxyPool.DATACENTER,
+    os: OperatingSystem.LINUX,
+});
+
+const wsUrl = client.cloudBrowser(config);
+
+const browser = await puppeteer.connect({
+    browserWSEndpoint: wsUrl,
+});
+
+const page = await browser.newPage();
+await page.goto('https://web-scraping.dev/products');
+
+const title = await page.title();
+console.log('Page title:', title);
+
+// Extract product data
+const products = await page.evaluate(() => {
+    return Array.from(document.querySelectorAll('.product')).map(el => ({
+        title: el.querySelector('.product-title')?.textContent?.trim(),
+        price: el.querySelector('.product-price')?.textContent?.trim(),
+    }));
+});
+console.log('Products:', products);
+
+await browser.close();

--- a/examples/browser/session_resume.mjs
+++ b/examples/browser/session_resume.mjs
@@ -1,0 +1,52 @@
+/**
+ * Session Resume with Scrapfly Cloud Browser
+ *
+ * npm install scrapfly-sdk puppeteer-core
+ */
+import { ScrapflyClient, BrowserConfig } from 'scrapfly-sdk';
+import puppeteer from 'puppeteer-core';
+
+const client = new ScrapflyClient({
+    key: 'YOUR_API_KEY',
+});
+
+const SESSION_ID = 'my-persistent-session';
+
+const config = new BrowserConfig({
+    proxy_pool: 'datacenter',
+    os: 'linux',
+    session: SESSION_ID,
+    auto_close: false,  // Keep browser alive after disconnect
+});
+
+const wsUrl = client.cloudBrowser(config);
+
+// First connection: navigate and set cookies
+console.log('=== First Connection ===');
+let browser = await puppeteer.connect({ browserWSEndpoint: wsUrl });
+let page = await browser.newPage();
+await page.goto('https://web-scraping.dev');
+await page.setCookie({
+    name: 'session_token',
+    value: 'abc123',
+    domain: 'web-scraping.dev',
+});
+console.log('Cookies set, disconnecting...');
+await browser.disconnect();  // Keep browser alive
+
+// Wait a bit
+await new Promise(r => setTimeout(r, 2000));
+
+// Second connection: cookies are preserved
+console.log('=== Second Connection ===');
+browser = await puppeteer.connect({ browserWSEndpoint: wsUrl });
+const pages = await browser.pages();
+page = pages[0] || await browser.newPage();
+const cookies = await page.cookies('https://web-scraping.dev');
+console.log('Cookies from previous session:', cookies);
+
+await browser.close();
+
+// Stop the session when done
+await client.cloudBrowserSessionStop(SESSION_ID);
+console.log('Session stopped');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,401 @@
+{
+  "name": "typescript",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "scrapfly-sdk": "file:npm"
+      }
+    },
+    "node_modules/@deno/shim-deno": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.18.2.tgz",
+      "integrity": "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno-test": "^0.5.0",
+        "which": "^4.0.0"
+      }
+    },
+    "node_modules/@deno/shim-deno-test": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.5.0.tgz",
+      "integrity": "sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/scrapfly-sdk": {
+      "resolved": "npm",
+      "link": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "npm": {
+      "name": "scrapfly-sdk",
+      "version": "0.7.3",
+      "license": "BSD",
+      "dependencies": {
+        "@deno/shim-deno": "~0.18.0",
+        "cheerio": "1.0.0-rc.12"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.9.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "scrapfly-sdk": "file:npm"
+  }
+}

--- a/src/browserconfig.ts
+++ b/src/browserconfig.ts
@@ -1,0 +1,114 @@
+export enum ProxyPool {
+  DATACENTER = 'datacenter',
+  RESIDENTIAL = 'residential',
+}
+
+export enum OperatingSystem {
+  LINUX = 'linux',
+  WINDOWS = 'windows',
+  MACOS = 'macos',
+}
+
+export type BrowserConfigOptions = {
+  proxy_pool?: ProxyPool | string;
+  os?: OperatingSystem | string;
+  session?: string;
+  country?: string;
+  auto_close?: boolean;
+  timeout?: number;
+  debug?: boolean;
+  extensions?: string[];
+  block_images?: boolean;
+  block_styles?: boolean;
+  block_fonts?: boolean;
+  block_media?: boolean;
+  screenshot?: boolean;
+  resolution?: string;
+  target_url?: string;
+  cache?: boolean;
+  blacklist?: boolean;
+  unblock?: boolean;
+  unblock_timeout?: number;
+  browser_brand?: string;
+};
+
+export class BrowserConfig {
+  proxy_pool?: string;
+  os?: string;
+  session?: string;
+  country?: string;
+  auto_close?: boolean;
+  timeout?: number;
+  debug?: boolean;
+  extensions?: string[];
+  block_images?: boolean;
+  block_styles?: boolean;
+  block_fonts?: boolean;
+  block_media?: boolean;
+  screenshot?: boolean;
+  resolution?: string;
+  target_url?: string;
+  cache?: boolean;
+  blacklist?: boolean;
+  unblock?: boolean;
+  unblock_timeout?: number;
+  browser_brand?: string;
+
+  constructor(options: BrowserConfigOptions = {}) {
+    if (options.timeout !== undefined && options.timeout > 1800) {
+      throw new Error('timeout cannot exceed 1800 seconds (30 minutes)');
+    }
+    this.proxy_pool = options.proxy_pool;
+    this.os = options.os;
+    this.session = options.session;
+    this.country = options.country;
+    this.auto_close = options.auto_close;
+    this.timeout = options.timeout;
+    this.debug = options.debug;
+    this.extensions = options.extensions;
+    this.block_images = options.block_images;
+    this.block_styles = options.block_styles;
+    this.block_fonts = options.block_fonts;
+    this.block_media = options.block_media;
+    this.screenshot = options.screenshot;
+    this.resolution = options.resolution;
+    this.target_url = options.target_url;
+    this.cache = options.cache;
+    this.blacklist = options.blacklist;
+    this.unblock = options.unblock;
+    this.unblock_timeout = options.unblock_timeout;
+    this.browser_brand = options.browser_brand;
+  }
+
+  /**
+   * Generate the WebSocket URL for a Cloud Browser session.
+   */
+  websocketUrl(apiKey: string, host?: string): string {
+    const params = new URLSearchParams();
+    params.set('api_key', apiKey);
+
+    if (this.proxy_pool !== undefined) params.set('proxy_pool', this.proxy_pool);
+    if (this.os !== undefined) params.set('os', this.os);
+    if (this.session !== undefined) params.set('session', this.session);
+    if (this.country !== undefined) params.set('country', this.country);
+    if (this.auto_close !== undefined) params.set('auto_close', String(this.auto_close));
+    if (this.timeout !== undefined) params.set('timeout', String(this.timeout));
+    if (this.debug !== undefined) params.set('debug', String(this.debug));
+    if (this.extensions && this.extensions.length > 0) params.set('extensions', this.extensions.join(','));
+    if (this.block_images !== undefined) params.set('block_images', String(this.block_images));
+    if (this.block_styles !== undefined) params.set('block_styles', String(this.block_styles));
+    if (this.block_fonts !== undefined) params.set('block_fonts', String(this.block_fonts));
+    if (this.block_media !== undefined) params.set('block_media', String(this.block_media));
+    if (this.screenshot !== undefined) params.set('screenshot', String(this.screenshot));
+    if (this.resolution !== undefined) params.set('resolution', this.resolution);
+    if (this.target_url !== undefined) params.set('target_url', this.target_url);
+    if (this.cache !== undefined) params.set('cache', String(this.cache));
+    if (this.blacklist !== undefined) params.set('blacklist', String(this.blacklist));
+    if (this.unblock !== undefined) params.set('unblock', String(this.unblock));
+    if (this.unblock_timeout !== undefined) params.set('unblock_timeout', String(this.unblock_timeout));
+    if (this.browser_brand !== undefined) params.set('browser_brand', this.browser_brand);
+
+    const baseHost = host || 'wss://browser.scrapfly.io';
+    return `${baseHost}?${params.toString()}`;
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,26 +1,35 @@
 import { path } from './deps.ts';
-import { mkdir, writeFile } from './polyfill.ts';
+import { mkdir, writeFile, readFileSync } from './polyfill.ts';
 import { fetchRetry } from './utils.ts';
 import * as errors from './errors.ts';
 import type { ScrapeConfig } from './scrapeconfig.ts';
 import type { ScreenshotConfig } from './screenshotconfig.ts';
 import type { ExtractionConfig } from './extractionconfig.ts';
+import { BrowserConfig } from './browserconfig.ts';
 import { type AccountData, ExtractionResult, ScrapeResult, ScreenshotResult } from './result.ts';
 import { log } from './logger.ts';
 import type { Rec } from './types.ts';
 
 export class ScrapflyClient {
   public HOST = 'https://api.scrapfly.io';
+  public CLOUD_BROWSER_HOST = 'wss://browser.scrapfly.io';
+  public CLOUD_BROWSER_API_HOST = 'https://browser.scrapfly.io';
   private key: string;
   private ua: string;
+  private cloudBrowserHost: string;
+  private cloudBrowserApiHost: string;
   fetch = fetchRetry;
 
-  constructor(options: { key: string }) {
+  constructor(options: { key: string; cloudBrowserHost?: string }) {
     if (typeof options.key !== 'string' || options.key.trim() === '') {
       throw new errors.BadApiKeyError('Invalid key. Key must be a non-empty string');
     }
     this.key = options.key;
     this.ua = 'Typescript Scrapfly SDK';
+    this.cloudBrowserHost = options.cloudBrowserHost || this.CLOUD_BROWSER_HOST;
+    this.cloudBrowserApiHost = options.cloudBrowserHost
+      ? options.cloudBrowserHost.replace('wss://', 'https://')
+      : this.CLOUD_BROWSER_API_HOST;
   }
 
   /**
@@ -410,5 +419,261 @@ export class ScrapflyClient {
     }
     const result = await this.handleExtractionResponse(response);
     return result;
+  }
+
+  // --- Cloud Browser ---
+
+  /**
+   * Get the WebSocket URL for a Cloud Browser session.
+   */
+  cloudBrowser(config?: BrowserConfig): string {
+    const browserConfig = config || new BrowserConfig();
+    return browserConfig.websocketUrl(this.key, this.cloudBrowserHost);
+  }
+
+  /**
+   * Call the Cloud Browser Unblock API.
+   */
+  async cloudBrowserUnblock(options: {
+    url: string;
+    proxy_pool?: string;
+    country?: string;
+    os?: string;
+    timeout?: number;
+    browser_timeout?: number;
+    headers?: Record<string, string>;
+    body?: string;
+    method?: string;
+  }): Promise<{ ws_url: string; session_id: string; run_id: string }> {
+    const proxyPoolMap: Record<string, string> = {
+      datacenter: 'public_datacenter_pool',
+      residential: 'public_residential_pool',
+    };
+
+    const jsonBody: Record<string, unknown> = { url: options.url };
+    if (options.proxy_pool) jsonBody.proxy_pool = proxyPoolMap[options.proxy_pool] || options.proxy_pool;
+    if (options.country) jsonBody.country = options.country;
+    if (options.os) jsonBody.os = options.os;
+    if (options.timeout) jsonBody.timeout = options.timeout;
+    if (options.browser_timeout) jsonBody.browser_timeout = options.browser_timeout;
+    if (options.headers) jsonBody.headers = options.headers;
+    if (options.body) jsonBody.body = options.body;
+    if (options.method) jsonBody.method = options.method;
+
+    const url = new URL(this.cloudBrowserApiHost + '/unblock');
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': this.ua,
+      },
+      body: JSON.stringify(jsonBody),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Unblock failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as { ws_url: string; session_id: string; run_id: string };
+  }
+
+  /**
+   * Stop a Cloud Browser session.
+   */
+  async cloudBrowserSessionStop(sessionId: string): Promise<void> {
+    const url = new URL(this.cloudBrowserApiHost + '/session/' + sessionId + '/stop');
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'POST',
+      headers: { 'user-agent': this.ua },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Session stop failed: ${response.status} ${await response.text()}`);
+    }
+  }
+
+  /**
+   * List all browser extensions.
+   */
+  async cloudBrowserExtensionList(): Promise<{ extensions: any[]; quota: { used: number; limit: number } }> {
+    const url = new URL(this.cloudBrowserApiHost + '/extension');
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'GET',
+      headers: { 'user-agent': this.ua },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Extension list failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as { extensions: any[]; quota: { used: number; limit: number } };
+  }
+
+  /**
+   * Delete a browser extension.
+   */
+  async cloudBrowserExtensionDelete(extensionId: string): Promise<{ success: boolean; message: string }> {
+    const url = new URL(this.cloudBrowserApiHost + '/extension/' + extensionId);
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'DELETE',
+      headers: { 'user-agent': this.ua },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Extension delete failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as { success: boolean; message: string };
+  }
+
+  /**
+   * Get details of a specific browser extension.
+   */
+  async cloudBrowserExtensionGet(extensionId: string): Promise<Record<string, any>> {
+    const url = new URL(this.cloudBrowserApiHost + '/extension/' + extensionId);
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'GET',
+      headers: { 'user-agent': this.ua },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Extension get failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as Record<string, any>;
+  }
+
+  /**
+   * Upload a browser extension from a local file (.zip or .crx).
+   * Pass a file path — the file is read and sent as multipart/form-data.
+   */
+  async cloudBrowserExtensionUpload(filePath: string): Promise<{ extension: Record<string, any>; is_update: boolean }> {
+    const fileBytes = readFileSync(filePath);
+    const fileName = filePath.split('/').pop() || filePath.split('\\').pop() || 'extension.zip';
+    const boundary = '----ScrapflyBoundary' + Date.now();
+
+    const encoder = new TextEncoder();
+    const header = encoder.encode(
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${fileName}"\r\nContent-Type: application/octet-stream\r\n\r\n`
+    );
+    const footer = encoder.encode(`\r\n--${boundary}--\r\n`);
+
+    const body = new Uint8Array(header.length + fileBytes.length + footer.length);
+    body.set(header, 0);
+    body.set(fileBytes, header.length);
+    body.set(footer, header.length + fileBytes.length);
+
+    const url = new URL(this.cloudBrowserApiHost + '/extension');
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'POST',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+        'user-agent': this.ua,
+      },
+      body: body,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Extension upload failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as { extension: Record<string, any>; is_update: boolean };
+  }
+
+  /**
+   * Install a browser extension from a URL (.crx file).
+   * URL-based extensions auto-update on each browser session start.
+   */
+  async cloudBrowserExtensionUploadFromUrl(extensionUrl: string): Promise<{ extension: Record<string, any>; is_update: boolean }> {
+    const url = new URL(this.cloudBrowserApiHost + '/extension');
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': this.ua,
+      },
+      body: JSON.stringify({ extension_url: extensionUrl }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Extension upload from URL failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as { extension: Record<string, any>; is_update: boolean };
+  }
+
+  /**
+   * Download a debug session recording video.
+   * Returns the video as an ArrayBuffer (stream from server).
+   */
+  async cloudBrowserVideo(runId: string): Promise<{ data: ArrayBuffer; filename: string }> {
+    const url = new URL(this.cloudBrowserApiHost + '/run/' + runId + '/video');
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'GET',
+      headers: { 'user-agent': this.ua },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Video download failed: ${response.status} ${await response.text()}`);
+    }
+
+    const filename = runId + '.webm';
+    return { data: await response.arrayBuffer(), filename };
+  }
+
+  /**
+   * Get playback info for a debug session recording.
+   */
+  async cloudBrowserPlayback(runId: string): Promise<Record<string, any>> {
+    const url = new URL(this.cloudBrowserApiHost + '/run/' + runId + '/playback');
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'GET',
+      headers: { 'user-agent': this.ua },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Playback get failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as Record<string, any>;
+  }
+
+  /**
+   * List all running Cloud Browser sessions.
+   */
+  async cloudBrowserSessions(): Promise<{ sessions: any[]; total: number }> {
+    const url = new URL(this.cloudBrowserApiHost + '/sessions');
+    url.searchParams.set('key', this.key);
+
+    const response = await this.fetch({
+      url: url.toString(),
+      method: 'GET',
+      headers: { 'user-agent': this.ua },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Sessions list failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as { sessions: any[]; total: number };
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ export {
 } from './scrapeconfig.ts';
 export { Format as ScreenshotFormat, Options as ScreenshotOptions, ScreenshotConfig } from './screenshotconfig.ts';
 export { ExtractionConfig } from './extractionconfig.ts';
+export { BrowserConfig, ProxyPool, OperatingSystem } from './browserconfig.ts';
 export * as errors from './errors.ts';
 
 export { ExtractionResult, ScrapeResult, ScreenshotResult } from './result.ts';

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,4 +1,17 @@
 export const isDeno = typeof Deno !== 'undefined';
+// @ts-ignore: Bun global
+export const isBun = typeof Bun !== 'undefined';
+
+export function readFileSync(path: string): Uint8Array {
+  if (isDeno) {
+    return Deno.readFileSync(path);
+  }
+  // Node.js / Bun — both support require('fs')
+  // deno-lint-ignore no-var
+  // @ts-ignore: dynamic require for Node/Bun
+  var fs = require('fs');
+  return new Uint8Array(fs.readFileSync(path));
+}
 
 export async function mkdir(path: string | URL, options: Deno.MkdirOptions): Promise<void> {
   if (isDeno) {

--- a/src/scrapeconfig.ts
+++ b/src/scrapeconfig.ts
@@ -83,6 +83,7 @@ type ScrapeConfigOptions = {
   os?: string;
   lang?: string[];
   auto_scroll?: boolean;
+  browser_brand?: string;
 };
 
 export class ScrapeConfig {
@@ -130,6 +131,7 @@ export class ScrapeConfig {
   lang?: string[];
   os?: string;
   auto_scroll?: boolean;
+  browser_brand?: string;
 
   constructor(options: ScrapeConfigOptions) {
     this.validateOptions(options);
@@ -192,6 +194,7 @@ export class ScrapeConfig {
     this.os = options.os ?? this.os;
     this.lang = options.lang ?? this.lang;
     this.auto_scroll = options.auto_scroll ?? this.auto_scroll;
+    this.browser_brand = options.browser_brand ?? this.browser_brand;
     this.dns = options.dns ?? this.dns;
     this.ssl = options.ssl ?? this.ssl;
     this.debug = options.debug ?? this.debug;
@@ -395,6 +398,9 @@ export class ScrapeConfig {
     }
     if (this.os !== undefined) {
       params.os = this.os;
+    }
+    if (this.browser_brand !== undefined) {
+      params.browser_brand = this.browser_brand;
     }
 
     return params;


### PR DESCRIPTION
## Summary

Add Cloud Browser support to the SDK.

- `BrowserConfig` exposes the full Cloud Browser parameter surface (`proxy_pool`, `os`, `country`, `session`, `auto_close`, `timeout`, `debug`, `extensions`, `block_images`, `block_styles`, `block_fonts`, `block_media`, `screenshot`, `resolution`, `target_url`, `cache`, `blacklist`, `unblock`, `unblock_timeout`, `browser_brand`, `byop_proxy`).
- `ScrapflyClient.cloudBrowser(config)` builds the WebSocket URL ready for `playwright.connectOverCDP()` / `puppeteer.connect()`.
- `byop_proxy` accepts `http`, `https`, `socks5`, `socks5h`, `socks5+udp`, `socks5h+udp`. The `+udp` variants enable HTTP/3 (QUIC) via SOCKS5 UDP ASSOCIATE for providers that implement RFC 1928 §7.

See https://scrapfly.io/docs/cloud-browser-api/getting-started

## Test plan

- [ ] `new BrowserConfig({...}).websocketUrl(apiKey)` returns a valid `wss://browser.scrapfly.io?...` URL
- [ ] `byop_proxy: 'socks5h+udp://...'` is properly URL-encoded as `byop_proxy=socks5h%2Budp%3A%2F%2F...`
- [ ] Connect via `playwright.connectOverCDP(client.cloudBrowser(config))` against the live Cloud Browser endpoint